### PR TITLE
Add publish workflow for release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
 
 jobs:
   release:
@@ -22,3 +24,23 @@ jobs:
           tag_prefix: v
       - name: Echo created tag
         run: echo "Created ${{ steps.tagger.outputs.new_tag }}"
+      - name: Set up Python
+        if: steps.tagger.outputs.new_tag != ''
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install build tools
+        if: steps.tagger.outputs.new_tag != ''
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - name: Build package
+        if: steps.tagger.outputs.new_tag != ''
+        run: python -m build
+      - name: Publish package
+        if: steps.tagger.outputs.new_tag != ''
+        env:
+          TWINE_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+        run: |
+          twine upload --repository-url ${{ secrets.ARTIFACTORY_URL }} dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .env
 .vscode/
 .idea/
+dist/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ After the tests pass, the PR can be merged once it has been approved.
 Merged commits on `main` are scanned for Conventional Commit messages.
 A separate workflow uses a public GitHub Action to calculate the next semantic
 version and automatically push the corresponding `vX.Y.Z` tag.
+These tags then trigger another workflow that builds the package and
+publishes it to our private PyPI server automatically.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "btree"
+version = "0.1.0"
+description = "B-Tree Implementation in Python"
+readme = "README.md"
+license = {file = "LICENSE"}
+authors = [{name = "Example"}]
+requires-python = ">=3.7"
+


### PR DESCRIPTION
## Summary
- auto publish packages from `release.yml`
- ignore build artifacts
- add minimal packaging info
- document automatic publishing

## Testing
- `python -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_6875436f1420832db3eb5ac8538a017e