### PR TITLE
Fix release action permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,13 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- allow write permissions for release job

## Testing
- `python -m pip install --upgrade pip`
- `python -m unittest -v`


------
https://chatgpt.com/codex/tasks/task_e_6875446ed5bc832d946a65ce0e51c68d