### PR TITLE
Add publishing workflow steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,23 @@ jobs:
           tag_prefix: v
       - name: Echo created tag
         run: echo "Created ${{ steps.tagger.outputs.new_tag }}"
+      - name: Set up Python
+        if: steps.tagger.outputs.new_tag != ''
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install build dependencies
+        if: steps.tagger.outputs.new_tag != ''
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - name: Build package
+        if: steps.tagger.outputs.new_tag != ''
+        run: python -m build
+      - name: Publish to Artifactory
+        if: steps.tagger.outputs.new_tag != ''
+        env:
+          TWINE_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          TWINE_REPOSITORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+        run: twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ After the tests pass, the PR can be merged once it has been approved.
 Merged commits on `master` are scanned for Conventional Commit messages.
 A separate workflow uses a public GitHub Action to calculate the next semantic
 version and automatically push the corresponding `vX.Y.Z` tag.
+Whenever a tag is created, another step builds the package and publishes it to
+the configured Artifactory PyPI repository.
 
 ## License
 


### PR DESCRIPTION
## Summary
- automatically build and upload wheel/sdist when a release tag is created
- mention automatic publishing in the README

## Testing
- `python -m pip install --upgrade pip`
- `python -m unittest -v`


------
https://chatgpt.com/codex/tasks/task_e_68754cca8b98832d8dcbac57250af91c